### PR TITLE
Reverting back to old urls

### DIFF
--- a/app/controllers/HelpAndContactController.scala
+++ b/app/controllers/HelpAndContactController.scala
@@ -23,12 +23,11 @@ import handlers.ErrorHandler
 import javax.inject.Inject
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import play.twirl.api.{Html, HtmlFormat}
+import play.twirl.api.Html
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import utils.LoggingUtil
 import views.html.help_and_contact
 
-import scala.concurrent.ExecutionContext
 import models.PageType
 import services.{PageTypeResolverService}
 
@@ -44,12 +43,12 @@ class HelpAndContactController @Inject()(
                                         ) extends FrontendController(controllerComponents)
   with I18nSupport with LoggingUtil {
 
-  def mainPage: Action[AnyContent] = renderPage(PageType.HelpWithBTA.name)
+  def mainPage: Action[AnyContent] = renderPage(PageType.HelpWithBTA.route)
 
   def renderPage(pageType: String): Action[AnyContent] = (authenticate andThen serviceInfo) { implicit request =>
-    PageType.withName(pageType) match {
+    PageType.values.find(p => p.route == pageType) match {
       case Some(validPageType) if validPageType.externalUrl.isDefined =>
-         Redirect(validPageType.externalUrl.get)
+        Redirect(validPageType.externalUrl.get)
       case Some(validPageType) =>
         val dynamicContent: Html = viewResolver.resolve(validPageType)
         Ok(help_and_contact(appConfig)(
@@ -58,7 +57,6 @@ class HelpAndContactController @Inject()(
           validPageType.name,
           PageType.values
         ))
-        
       case None =>
         NotFound(errorHandler.notFoundTemplate)
     }

--- a/app/models/PageType.scala
+++ b/app/models/PageType.scala
@@ -16,13 +16,12 @@
 
 package models
 
-import models.HelpCategory.VAT
-
 sealed trait PageType {
   def name: String
   def messageKey: String
   def category: HelpCategory
-  def externalUrl: Option[String] = None 
+  def externalUrl: Option[String] = None
+  def route: String
 }
 
 object PageType {
@@ -30,48 +29,56 @@ object PageType {
     val name = "help-with-bta"
     val messageKey = "help_and_contact.help_with_business_tax_account"
     val category = HelpCategory.BTA
+    val route = "help-with-your-business-tax-account"
   }
 
   case object ChangeContactAndAccountDetails extends PageType {
     val name = "change-contact-and-account-details"
     val messageKey = "help_and_contact.change_contact_and_account_details"
     val category = HelpCategory.BTA
+    val route = "change-your-details"
   }
 
   case object HowToAddTax extends PageType {
     val name = "how-to-add-tax"
     val messageKey = "help_and_contact.how_to_add_tax"
     val category = HelpCategory.BTA
+    val route = "how-to-add-tax"
   }
 
   case object RegisterOrDeregisterVAT extends PageType {
     val name = "register-or-deregister-vat"
     val messageKey = "help_and_contact.register_or_deregister"
     val category = HelpCategory.VAT
+    val route = "vat/register-or-deregister"
   }
 
   case object HowToPayVatAndDeadlines extends PageType {
     val name = "how-to-pay-vat-and-deadlines"
     val messageKey = "vat.payments_and_deadlines"
     val category = HelpCategory.VAT
+    val route = "vat/how-to-pay"
   }
 
   case object CorrectingErrorsOnReturns extends PageType {
     val name = "correcting-errors-on-returns"
     val messageKey = "vat.correcting_errors_on_returns"
     val category = HelpCategory.VAT
+    val route = "correcting-errors-on-returns"
   }
 
   case object GetStarted extends PageType {
     val name = "get-started-paye"
     val messageKey = "help_and_contact.get_started"
     val category = HelpCategory.Epaye
+    val route = "epaye/get-started"
   }
 
   case object ViewOrCorrectYourSubmissions extends PageType {
     val name = "view-or-correct-your-submissions"
     val messageKey = "help_and_contact.view_or_correct_submissions"
     val category = HelpCategory.Epaye
+    val route = "epaye/view-check-correct-submissions"
   }
 
 
@@ -79,85 +86,100 @@ object PageType {
     val name = "register-add-corporation-tax"
     val messageKey = "help_and_contact.register_add_corporation_tax"
     val category = HelpCategory.CorporationTax
+    val route = "register-add-corporation-tax"
   }
 
   case object HowToPayCT extends PageType {
     val name = "how-to-pay"
     val messageKey = "help_and_contact.how_to_pay_corporation_tax"
     val category = HelpCategory.CorporationTax
+    val route = "corporation-tax/how-to-pay"
   }
 
   case object ClosingLimitedCompanyCT extends PageType {
     val name = "closing-limited-company"
     val messageKey = "help_and_contact.closing_limited_company"
     val category = HelpCategory.CorporationTax
+    val route = "closing-limited-company"
   }
 
   case object GetUtrCT extends PageType {
     val name = "ask-your-corporation-tax-utr"
     val messageKey = "help_and_contact.get_ct_utr"
     val category = HelpCategory.CorporationTax
+    val route = "ask-for-copy-of-your-corporation-tax-utr"
+
   }
 
   case object ContactHMRC extends PageType {
     val name = "contact-hmrc"
     val messageKey = "help_and_contact.contact_hmrc.nav"
     val category = HelpCategory.GEN
+    val route = "corporation-tax/contact-hmrc"
   }
 
   case object PayeStopEmployer extends PageType {
     val name = "stop-being-an-employer"
     val messageKey = "help_and_contact.paye_stop_being_an_employer"
     val category = HelpCategory.Epaye
+    val route = "stop-being-an-employer"
   }
 
   case object PayeChangeCircumstance extends PageType {
     val name = "changes-in-employee-circumstances"
     val messageKey = "help_and_contact.paye_changes_employee_circumstances"
     val category = HelpCategory.Epaye
+    val route = "epaye/change-employee-circumstances"
   }
 
   case object PayeCisRefunds extends PageType {
     val name = "paye-and-cis-refunds"
     val messageKey = "help_and_contact.paye_cis_refunds"
     val category = HelpCategory.Epaye
+    val route = "refunds"
   }
 
   case object PaymentsAndPenalties extends PageType {
     val name = "payments-and-penalties"
     val messageKey = "help_and_contact.payments_and_penalties"
     val category = HelpCategory.SelfAssessment
+    val route = "self-assessment/payment-and-penalties"
   }
 
 
-    case object RegisteringOrStopping extends PageType {
+  case object RegisteringOrStopping extends PageType {
     val name = "registering-or-stopping"
     val messageKey = "help_and_contact.registering_or_stopping"
     val category = HelpCategory.SelfAssessment
+    val route = "self-assessment/register-or-stopping"
   }
 
   case object HelpWithSATaxReturn extends PageType {
     val name = "help-with-sa-tax-return"
     val messageKey = "help_and_contact.help_with_sa_tax_return"
     val category = HelpCategory.SelfAssessment
+    val route = "self-assessment/help-with-return"
   }
 
   case object GetEvidenceOfIncome extends PageType {
     val name = "get-evidence-of-income"
     val messageKey = "help_and_contact.get_evidence_of_income"
     val category = HelpCategory.SelfAssessment
+    val route = "self-assessment/evidence-of-income"
   }
 
   case object Expenses extends PageType {
     val name = "expenses"
     val messageKey = "help_and_contact.expenses"
     val category = HelpCategory.SelfAssessment
+    val route = "self-assessment/expenses"
   }
 
   case object SignUpForMTD extends PageType {
     val name = "sign-up-for-mtd"
     val messageKey = "help_and_contact.sign_up_for_mtd_for_income_tax_new_tab"
     val category = HelpCategory.SelfAssessment
+    val route = "https://www.gov.uk/guidance/sign-up-your-business-for-making-tax-digital-for-income-tax"
 
     override val externalUrl = Some("https://www.gov.uk/guidance/sign-up-your-business-for-making-tax-digital-for-income-tax")
   }

--- a/app/views/help_and_contact.scala.html
+++ b/app/views/help_and_contact.scala.html
@@ -41,7 +41,7 @@ serviceInfoContent = serviceInfoContent) {
     @for(pageLink <- filteredLinks) {
     <li class="@if(pageLink.name == name) {help-nav-active}">
       @link(
-        link = if(pageLink.externalUrl.isDefined) pageLink.externalUrl.get else routes.HelpAndContactController.renderPage(pageLink.name).toString,
+     link = if(pageLink.externalUrl.isDefined) pageLink.externalUrl.get else routes.HelpAndContactController.renderPage(pageLink.route).toString,
         messageKey = Messages(pageLink.messageKey),
         isExternal = pageLink.externalUrl.isDefined,
         additionalClasses = if (pageLink.name == name) "govuk-!-font-weight-bold" else "",

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -10,6 +10,6 @@ GET        /this-service-has-been-reset                controllers.SessionExpire
 
 GET        /unauthorised                               controllers.UnauthorisedController.onPageLoad
 
-GET        /:pageType                                  controllers.HelpAndContactController.renderPage(pageType: String)
 GET        /                                           controllers.HelpAndContactController.mainPage
 GET        /transcript/:videoTitle                      controllers.TranscriptController.onPageLoad(videoTitle: String)
+GET        /*pageType                                  controllers.HelpAndContactController.renderPage(pageType: String)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -235,8 +235,8 @@ vat.payments_and_deadlines.are_slightly_different_in_each_eu_country = are sligh
 vat.payments_and_deadlines.each_eu_country_has_set_a_minimun_amount_ = each EU country has set a minimum amount that can be refunded
 vat.payments_and_deadlines.if_your_business_makes_both_taxable_ = if your business makes both taxable and exempt supplies, you may not be able to reclaim all of the VAT you have been charged
 vat.payments_and_deadlines.how_to_pay_your_bill_link = Read detailed information about how to pay your VAT bill
-vat.payments_and_deadlines.how_to_get_help_link = Video - How to get help when you can’’t pay your tax bill (opens in a new tab)
-vat.payments_and_deadlines.how_to_get_help_transcript_link = How to get help when you can’’t pay your tax bill - video transcript
+vat.payments_and_deadlines.how_to_get_help_link = Video - How to get help when you can’t pay your tax bill (opens in a new tab)
+vat.payments_and_deadlines.how_to_get_help_transcript_link = How to get help when you can’t pay your tax bill - video transcript
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #~~ Register or Deregister

--- a/test/controllers/HelpAndContactControllerSpec.scala
+++ b/test/controllers/HelpAndContactControllerSpec.scala
@@ -56,7 +56,7 @@ class HelpAndContactControllerSpec extends ControllerSpecBase with MockitoSugar 
 
 
   val pageTypeTestCases = Seq(
-    "help-with-bta" -> views.html.general.help_with_your_bta(PageType.HelpWithBTA.name, frontendAppConfig)(messages),
+    "help-with-your-business-tax-account" -> views.html.general.help_with_your_bta(PageType.HelpWithBTA.route, frontendAppConfig)(messages),
   )
 
   "HelpAndContactController" should {

--- a/test/views/HelpAndContactViewSpec.scala
+++ b/test/views/HelpAndContactViewSpec.scala
@@ -58,39 +58,42 @@ class HelpAndContactViewSpec extends ViewBehaviours with GuiceOneAppPerSuite {
       val doc = asDocument(createView(page = "help-with-bta")())
 
       val linksToValidate = Seq(
-        ("Help with your business tax account", "/business-account/help/help-with-bta"),
-        ("Change contact and account details", "/business-account/help/change-contact-and-account-details"),
-        ("How to add a tax", "/business-account/help/how-to-add-tax"),
-        ("Payments and penalties", "/business-account/help/payments-and-penalties"),
-        ("Registering or stopping", "/business-account/help/registering-or-stopping"),
-        ("Help with SA tax return", "/business-account/help/help-with-sa-tax-return"),
-        ("Get evidence of income - SA302", "/business-account/help/get-evidence-of-income"),
-        ("Expenses", "/business-account/help/expenses"),
-        ("Sign up for MTD for Income Tax (opens in new tab)", "https://www.gov.uk/guidance/sign-up-your-business-for-making-tax-digital-for-income-tax"),
-        ("Register or deregister", "/business-account/help/register-or-deregister-vat"),
-        ("How to pay and deadlines", "/business-account/help/how-to-pay-vat-and-deadlines"),
-        ("Get started", "/business-account/help/get-started-paye"),
-        ("View or correct your submissions", "/business-account/help/view-or-correct-your-submissions"),
-        ("PAYE and CIS refunds", "/business-account/help/paye-and-cis-refunds"),
-        ("Changes in employee circumstances", "/business-account/help/changes-in-employee-circumstances"),
-        ("If you stop being an employer", "/business-account/help/stop-being-an-employer"),
-        ("Closing a limited company", "/business-account/help/closing-limited-company"),
-        ("Get a copy of your Unique Taxpayer Reference (UTR)", "/business-account/help/ask-your-corporation-tax-utr"),
-        ("Contact HMRC", "/business-account/help/contact-hmrc")
+        ("nav-link-help-with-bta", "Help with your business tax account", "/business-account/help/help-with-your-business-tax-account"),
+        ("nav-link-change-contact-and-account-details", "Change contact and account details", "/business-account/help/change-your-details"),
+        ("nav-link-how-to-add-tax", "How to add a tax", "/business-account/help/how-to-add-tax"),
+        ("nav-link-payments-and-penalties", "Payments and penalties", "/business-account/help/self-assessment/payment-and-penalties"),
+        ("nav-link-registering-or-stopping", "Registering or stopping", "/business-account/help/self-assessment/register-or-stopping"),
+        ("nav-link-help-with-sa-tax-return", "Help with SA tax return", "/business-account/help/self-assessment/help-with-return"),
+        ("nav-link-get-evidence-of-income", "Get evidence of income - SA302", "/business-account/help/self-assessment/evidence-of-income"),
+        ("nav-link-expenses", "Expenses", "/business-account/help/self-assessment/expenses"),
+        ("nav-link-sign-up-for-mtd", "Sign up for MTD for Income Tax (opens in new tab)", "https://www.gov.uk/guidance/sign-up-your-business-for-making-tax-digital-for-income-tax"),
+        ("nav-link-register-or-deregister-vat", "Register or deregister", "/business-account/help/vat/register-or-deregister"),
+        ("nav-link-how-to-pay-vat-and-deadlines", "How to pay and deadlines", "/business-account/help/vat/how-to-pay"),
+        ("nav-link-correcting-errors-on-returns", "Correcting errors on returns", "/business-account/help/correcting-errors-on-returns"),
+        ("nav-link-get-started-paye", "Get started", "/business-account/help/epaye/get-started"),
+        ("nav-link-view-or-correct-your-submissions", "View or correct your submissions", "/business-account/help/epaye/view-check-correct-submissions"),
+        ("nav-link-paye-and-cis-refunds", "PAYE and CIS refunds", "/business-account/help/refunds"),
+        ("nav-link-changes-in-employee-circumstances", "Changes in employee circumstances", "/business-account/help/epaye/change-employee-circumstances"),
+        ("nav-link-stop-being-an-employer", "If you stop being an employer", "/business-account/help/stop-being-an-employer"),
+        ("nav-link-register-add-corporation-tax", "Register or add Corporation Tax", "/business-account/help/register-add-corporation-tax"),
+        ("nav-link-how-to-pay", "How to pay and deadlines", "/business-account/help/corporation-tax/how-to-pay"),
+        ("nav-link-closing-limited-company", "Closing a limited company", "/business-account/help/closing-limited-company"),
+        ("nav-link-ask-your-corporation-tax-utr", "Get a copy of your Unique Taxpayer Reference (UTR)", "/business-account/help/ask-for-copy-of-your-corporation-tax-utr"),
+        ("nav-link-contact-hmrc", "Contact HMRC", "/business-account/help/corporation-tax/contact-hmrc")
       )
 
-      linksToValidate.foreach { case (linkText, url) =>
-        s"contain '$linkText' link" in {
-          assertLinkByText(doc, linkText, url)
-        }
-
-        def assertLinkByText(doc: Document, linkText: String, expectedUrl: String): Unit = {
-          val links = doc.select("a")
-          val link: Option[Element] = links.find(_.text() == linkText)
-          assert(link.isDefined, s"Link with text '$linkText' not found")
-          assert(link.get.attr("href") == expectedUrl, s"Link with text '$linkText' does not point to '$expectedUrl'")
-        }
+      linksToValidate.foreach { case (id, linkText, url) =>
+        s"contain link with id '$id', text '$linkText', and URL '$url'" in {
+          assertLinkById(doc, id, linkText, url)
         }
       }
+
+      def assertLinkById(doc: Document, id: String, expectedText: String, expectedUrl: String): Unit = {
+        val link = doc.select(s"a#$id").first()
+        assert(link != null, s"Link with id '$id' not found")
+        assert(link.text() == expectedText, s"Link with id '$id' does not have expected text '$expectedText'")
+        assert(link.attr("href") == expectedUrl, s"Link with id '$id' does not point to '$expectedUrl'")
+      }
     }
+  }
 }


### PR DESCRIPTION
For the reviewer on top of our usual checks:

- [ ]  cross check the old urls from this repo, here is the existing doc: https://confluence.tools.tax.service.gov.uk/display/DLS/DL-15493+-+Help+and+Contact+%3A+URL+Mapping

- [ ]  unit test logic slightly changed to cross check the links with id, linkText and url, it was only linkText and url.